### PR TITLE
Configurable Server Base URL

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+FHIR_SERVER_BASE_HOST=dev.careconnect.nhs.uk

--- a/ccri-fhirgateway/src/main/java/uk/nhs/careconnect/ri/gateway/CamelRoute.java
+++ b/ccri-fhirgateway/src/main/java/uk/nhs/careconnect/ri/gateway/CamelRoute.java
@@ -16,7 +16,7 @@ public class CamelRoute extends RouteBuilder {
 	protected Environment env;
 
 	@Value("${fhir.restserver.serverBase}")
-	private static String serverBase;
+	private String serverBase;
 	
     @Override
     public void configure() 
@@ -29,8 +29,7 @@ public class CamelRoute extends RouteBuilder {
 		from("direct:HAPIServer")
             .routeId("INT HAPI Server")
 				.to("log:uk.nhs.careconnect?level=INFO&showHeaders=true&showHeaders=true")
-				// TODO line below needs to be turned into config
-                .to("http4://ccri:8080/careconnect-ri/STU3?throwExceptionOnFailure=false&bridgeEndpoint=true")
+                .to(serverBase)
 				.convertBodyTo(InputStream.class);
 
     }

--- a/ccri-fhirgateway/src/main/java/uk/nhs/careconnect/ri/gateway/HAPIRestfulConfig.java
+++ b/ccri-fhirgateway/src/main/java/uk/nhs/careconnect/ri/gateway/HAPIRestfulConfig.java
@@ -24,7 +24,7 @@ public class HAPIRestfulConfig extends RestfulServer {
 	private WebApplicationContext myAppCtx;
 
 	@Value("${fhir.resource.serverBase}")
-	private static String serverBase = "http://dev.careconnect.nhs.uk/careconnect/STU3";
+	private String serverBase;
 
 	@SuppressWarnings("unchecked")
 	@Override

--- a/ccri-fhirgateway/src/main/java/uk/nhs/careconnect/ri/gateway/UIOverlayConfig.java
+++ b/ccri-fhirgateway/src/main/java/uk/nhs/careconnect/ri/gateway/UIOverlayConfig.java
@@ -40,9 +40,6 @@ public class UIOverlayConfig {
 	@Value("${datasource.ui.serverBase:}")
 	private String serverBase;
 
-//	@Value("${datasource.ui.server:}")
-//	private String serverUIBase;
-//
 	@Bean
 	public TesterConfig testerConfig() {
 		TesterConfig retVal = new TesterConfig();

--- a/ccri-fhirgateway/src/main/java/uk/nhs/careconnect/ri/gateway/UIOverlayConfig.java
+++ b/ccri-fhirgateway/src/main/java/uk/nhs/careconnect/ri/gateway/UIOverlayConfig.java
@@ -40,9 +40,9 @@ public class UIOverlayConfig {
 	@Value("${datasource.ui.serverBase:}")
 	private String serverBase;
 
-	@Value("${datasource.ui.server:}")
-	private String serverUIBase;
-
+//	@Value("${datasource.ui.server:}")
+//	private String serverUIBase;
+//
 	@Bean
 	public TesterConfig testerConfig() {
 		TesterConfig retVal = new TesterConfig();

--- a/ccri-fhirgateway/src/main/resources/application.properties
+++ b/ccri-fhirgateway/src/main/resources/application.properties
@@ -5,5 +5,5 @@ conf.software.name=CCRI-Gateway
 
 # NB dev.careconnect.nhs.uk is aliased to ccri
 datasource.ui.serverBase=http://dev.careconnect.nhs.uk/careconnect-ri/STU3
-fhir.resource.serverBase=http://dev.careconnect.nhs.uk/careconnect-ri
+fhir.resource.serverBase=http://dev.careconnect.nhs.uk/careconnect-ri/STU3
 fhir.restserver.serverBase=http4://dev.careconnect.nhs.uk/careconnect-ri/STU3?throwExceptionOnFailure=false&bridgeEndpoint=true

--- a/ccri-fhirserver/pom.xml
+++ b/ccri-fhirserver/pom.xml
@@ -372,16 +372,16 @@
 				</executions>
 			</plugin>
 
-			<plugin>
-				<groupId>org.apache.tomcat.maven</groupId>
-				<artifactId>tomcat7-maven-plugin</artifactId>
-				<version>2.2</version>
-				<configuration>
-					<url>http://dev.careconnect.nhs.uk/manager/text</url>
-					<server>TomcatServer</server>
-                    <path>/careconnect-ri</path>
-				</configuration>
-			</plugin>
+			<!--<plugin>-->
+				<!--<groupId>org.apache.tomcat.maven</groupId>-->
+				<!--<artifactId>tomcat7-maven-plugin</artifactId>-->
+				<!--<version>2.2</version>-->
+				<!--<configuration>-->
+					<!--<url>http://dev.careconnect.nhs.uk/manager/text</url>-->
+					<!--<server>TomcatServer</server>-->
+                    <!--<path>/careconnect-ri</path>-->
+				<!--</configuration>-->
+			<!--</plugin>-->
 
 		</plugins>
 	</build>

--- a/ccri-fhirserver/pom.xml
+++ b/ccri-fhirserver/pom.xml
@@ -372,17 +372,6 @@
 				</executions>
 			</plugin>
 
-			<!--<plugin>-->
-				<!--<groupId>org.apache.tomcat.maven</groupId>-->
-				<!--<artifactId>tomcat7-maven-plugin</artifactId>-->
-				<!--<version>2.2</version>-->
-				<!--<configuration>-->
-					<!--<url>http://dev.careconnect.nhs.uk/manager/text</url>-->
-					<!--<server>TomcatServer</server>-->
-                    <!--<path>/careconnect-ri</path>-->
-				<!--</configuration>-->
-			<!--</plugin>-->
-
 		</plugins>
 	</build>
 

--- a/ccri-fhirserver/server.xml
+++ b/ccri-fhirserver/server.xml
@@ -69,6 +69,10 @@
     <Connector port="80" protocol="HTTP/1.1"
                connectionTimeout="20000"
                redirectPort="8443" />
+    <!-- Define a second port which can provide access to the CCRI Dockerised App -->
+    <Connector port="8080" protocol="HTTP/1.1"
+               connectionTimeout="20000"
+               redirectPort="8443" />
     <!-- A "Connector" using the shared thread pool-->
     <!--
     <Connector executor="tomcatThreadPool"

--- a/ccri-fhirserver/src/main/java/uk/nhs/careconnect/ri/fhirserver/HAPIRestfulConfig.java
+++ b/ccri-fhirserver/src/main/java/uk/nhs/careconnect/ri/fhirserver/HAPIRestfulConfig.java
@@ -8,6 +8,7 @@ import ca.uhn.fhir.rest.server.RestfulServer;
 import ca.uhn.fhir.rest.server.interceptor.IServerInterceptor;
 import ca.uhn.fhir.rest.server.interceptor.ResponseHighlighterInterceptor;
 import org.springframework.beans.factory.annotation.Autowire;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.web.context.ContextLoaderListener;
 import org.springframework.web.context.WebApplicationContext;
@@ -23,7 +24,8 @@ public class HAPIRestfulConfig extends RestfulServer {
 	private WebApplicationContext myAppCtx;
 
 
-	private static String serverBase = "http://dev.careconnect.nhs.uk/careconnect-ri/STU3";
+	@Value("${datasource.serverBase}")
+	private String serverBase;
 
 	@SuppressWarnings("unchecked")
 	@Override

--- a/ccri-fhirserver/src/main/java/uk/nhs/careconnect/ri/fhirserver/UIOverlayConfig.java
+++ b/ccri-fhirserver/src/main/java/uk/nhs/careconnect/ri/fhirserver/UIOverlayConfig.java
@@ -41,15 +41,12 @@ public class UIOverlayConfig {
     @Value("${datasource.ui.serverBase:}")
     private String serverBase;
 
-    @Value("${datasource.ui.server:}")
-    private String serverUIBase;
-
 	@Bean
 	public TesterConfig testerConfig() {
 		TesterConfig retVal = new TesterConfig();
 
 		if (serverBase == null || serverBase.isEmpty()) {
-			serverBase = "${serverBase}/STU3";
+			serverBase = "${serverBase}";
 		}
 		retVal
 			.addServer()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,8 +21,8 @@ services:
       - datasource.dialect=org.hibernate.dialect.MySQL57Dialect
       - datasource.ui.serverBase=http://${FHIR_SERVER_BASE_HOST}/careconnect-ri/STU3
       - datasource.serverBase=http://${FHIR_SERVER_BASE_HOST}/careconnect-ri/STU3
-#    ports:
-#      8080:8080
+    ports:
+      - 8080:8080
     extra_hosts:
       # Define an alias to loop back for REST Connections
       - "${FHIR_SERVER_BASE_HOST}:127.0.0.1"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,13 +19,13 @@ services:
       - datasource.showDdl=true
       - datasource.cleardown.cron=0 19 21 * * *
       - datasource.dialect=org.hibernate.dialect.MySQL57Dialect
-      - datasource.ui.serverBase=http://dev.careconnect.nhs.uk/careconnect-ri/STU3
-      - datasource.ui.server=http://dev.careconnect.nhs.uk/careconnect-ri/STU3
+      - datasource.ui.serverBase=http://${FHIR_SERVER_BASE_HOST}/careconnect-ri/STU3
+      - datasource.serverBase=http://${FHIR_SERVER_BASE_HOST}/careconnect-ri/STU3
 #    ports:
-#      - 8080:80
+#      8080:8080
     extra_hosts:
       # Define an alias to loop back for REST Connections
-      - "dev.careconnect.nhs.uk:127.0.0.1"
+      - "${FHIR_SERVER_BASE_HOST}:127.0.0.1"
     volumes:
       - tomcat-log-volume:/usr/local/tomcat/logs
     networks:
@@ -55,15 +55,16 @@ services:
     build: ccri-fhirgateway
     image: thorlogic/ccri-fhirgateway
     environment:
-      - fhir.resource.serverBase=http://dev.careconnect.nhs.uk/careconnect-ri
-      - fhir.restserver.serverBase=http4://dev.careconnect.nhs.uk/careconnect-ri/STU3?throwExceptionOnFailure=false&bridgeEndpoint=true
+      - datasource.ui.serverBase=http://${FHIR_SERVER_BASE_HOST}/careconnect-ri/STU3
+      - fhir.resource.serverBase=http://${FHIR_SERVER_BASE_HOST}/careconnect-ri/STU3
+      - fhir.restserver.serverBase=http4://${FHIR_SERVER_BASE_HOST}/careconnect-ri/STU3?throwExceptionOnFailure=false&bridgeEndpoint=true
     depends_on:
       - ccri
     ports:
       - 80:80
     extra_hosts:
       # Define an alias to the CCRI Container to ensure that the correct Server Base is displayed by HAPI
-      - "dev.careconnect.nhs.uk:172.168.240.10"
+      - "${FHIR_SERVER_BASE_HOST}:172.168.240.10"
     volumes:
       - gateway-log-volume:/usr/local/tomcat/logs
     networks:


### PR DESCRIPTION
Allow the Server Base URL Host to be overriden via environment variables supplied to docker-compose or docker run.
This will allow the application to be deployed to both the dev & live servers with minimal variation.