### PR TITLE
Ensure that Filebeat can handle multiline exception messages

### DIFF
--- a/filebeat/filebeat.yml
+++ b/filebeat/filebeat.yml
@@ -9,6 +9,10 @@ filebeat.prospectors:
   fields_under_root: true
   fields:
     service: ccri_tomcat
+  multiline.pattern: '^[0-9]{2}\-\w{3}-'
+  multiline.negate: true
+  multiline.match: after
+  multiline.maxlines: 100
 
 output:
   logstash:


### PR DESCRIPTION
Add grouping of multlines in the Tomcat log files to ensure that stack traces are grouped into a single message