### PR TITLE
Remove MySQL Healthcheck which was causing errors in the log file.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,10 +47,6 @@ services:
     networks:
       - ccri_net
     command: mysqld --character-set-server=utf8 --collation-server=utf8_bin --innodb_lock_wait_timeout=300 --transaction-isolation=READ-UNCOMMITTED
-    healthcheck:
-      test: ["CMD", "mysqladmin" ,"ping", "-h", "localhost"]
-      timeout: 20s
-      retries: 10
 
   ccrigateway:
     container_name: ccrigateway


### PR DESCRIPTION
This Healthcheck cannot be used to control start order of components & so was not being used.