### PR TITLE
webapp configuration of OAuth2 endpoints

### DIFF
--- a/ccri-fhirgateway/src/main/java/uk/nhs/careconnect/ri/gateway/http/Config.java
+++ b/ccri-fhirgateway/src/main/java/uk/nhs/careconnect/ri/gateway/http/Config.java
@@ -7,6 +7,9 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
+import org.springframework.beans.factory.annotation.Autowire;
+import ca.uhn.fhir.rest.server.interceptor.IServerInterceptor;
+import ca.uhn.fhir.rest.server.interceptor.ResponseHighlighterInterceptor;
 
 /**
  * Created by kevinmayfield on 21/07/2017.
@@ -20,12 +23,46 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 @ComponentScan(basePackages = "uk.nhs.careconnect.ri")
 public class Config {
 
+    @Value("${datasource.cleardown.cron:0 19 21 * * *}")
+    private String cron;
+
+    @Value("${fhir.resource.serverBase}")
+    private String serverBase;
+
+    @Value("${fhir.resource.serverName}")
+    private String serverName;
+
+    @Value("${fhir.resource.serverVersion}")
+    private String serverVersion;
+
+
+    public String getServerBase() {
+        return serverBase;
+    }
+
+    public String getServerName() {
+        return this.serverName;
+    }
+
+    public String getServerVersion() {
+        return this.serverVersion;
+    }
+
+    public String getCron() {
+        return this.cron;
+    }
+
     @Bean
     public FhirContext getFhirContext() {
         return FhirContext.forDstu3();
     }
 
-    @Value("${datasource.cleardown.cron:0 19 21 * * *}")
-    private String cron;
-
+    /**
+     * This interceptor adds some pretty syntax highlighting in responses when a browser is detected
+     */
+    @Bean(autowire = Autowire.BY_TYPE)
+    public IServerInterceptor responseHighlighterInterceptor() {
+        ResponseHighlighterInterceptor retVal = new ResponseHighlighterInterceptor();
+        return retVal;
+    }
 }

--- a/ccri-fhirgateway/src/main/java/uk/nhs/careconnect/ri/gateway/http/HAPIRestfulConfig.java
+++ b/ccri-fhirgateway/src/main/java/uk/nhs/careconnect/ri/gateway/http/HAPIRestfulConfig.java
@@ -6,13 +6,8 @@ import ca.uhn.fhir.rest.api.EncodingEnum;
 import ca.uhn.fhir.rest.server.FifoMemoryPagingProvider;
 import ca.uhn.fhir.rest.server.HardcodedServerAddressStrategy;
 import ca.uhn.fhir.rest.server.RestfulServer;
-import ca.uhn.fhir.rest.server.interceptor.IServerInterceptor;
-import ca.uhn.fhir.rest.server.interceptor.ResponseHighlighterInterceptor;
 import ca.uhn.fhir.util.VersionUtil;
 import org.hl7.fhir.dstu3.model.Composition;
-import org.springframework.beans.factory.annotation.Autowire;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Bean;
 import org.springframework.stereotype.Component;
 import org.springframework.web.context.ContextLoaderListener;
 import org.springframework.web.context.WebApplicationContext;
@@ -32,16 +27,6 @@ public class HAPIRestfulConfig extends RestfulServer {
 
 	private WebApplicationContext myAppCtx;
 
-	@Value("${fhir.resource.serverBase}")
-	private String serverBase;
-
-    @Value("${fhir.resource.serverName}")
-    private String serverName;
-
-    @Value("${fhir.resource.serverVersion}")
-    private String serverVersion;
-
-
     @Override
 	public void addHeadersToResponse(HttpServletResponse theHttpResponse) {
 		theHttpResponse.addHeader("X-Powered-By", "HAPI FHIR " + VersionUtil.getVersion() + " RESTful Server (NHS Care Connect STU3)");
@@ -59,6 +44,15 @@ public class HAPIRestfulConfig extends RestfulServer {
 
 		// Get the spring context from the web container (it's declared in web.xml)
 		myAppCtx = ContextLoaderListener.getCurrentWebApplicationContext();
+		Config cfg = myAppCtx.getBean(Config.class);
+  
+		String serverBase = cfg.getServerBase();
+		String serverName = cfg.getServerName();
+		String serverVersion = cfg.getServerVersion();
+
+		log.info("serverBase: " + serverBase);
+		log.info("serverName: " + serverName);
+		log.info("serverVersion: " + serverVersion);
 
         if (serverBase != null && !serverBase.isEmpty()) {
             setServerAddressStrategy(new HardcodedServerAddressStrategy(serverBase));
@@ -118,16 +112,4 @@ public class HAPIRestfulConfig extends RestfulServer {
 		FhirContext ctx = getFhirContext();
 		// Remove as believe due to issues on docker ctx.setNarrativeGenerator(new DefaultThymeleafNarrativeGenerator());
 	}
-
-	/**
-	 * This interceptor adds some pretty syntax highlighting in responses when a browser is detected
-	 */
-	@Bean(autowire = Autowire.BY_TYPE)
-	public IServerInterceptor responseHighlighterInterceptor() {
-		ResponseHighlighterInterceptor retVal = new ResponseHighlighterInterceptor();
-		return retVal;
-	}
-
-
-
 }

--- a/ccri-fhirgatewayhttps/src/main/java/uk/nhs/careconnect/ri/gateway/https/Config.java
+++ b/ccri-fhirgatewayhttps/src/main/java/uk/nhs/careconnect/ri/gateway/https/Config.java
@@ -7,6 +7,9 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
+import org.springframework.beans.factory.annotation.Autowire;
+import ca.uhn.fhir.rest.server.interceptor.IServerInterceptor;
+import ca.uhn.fhir.rest.server.interceptor.ResponseHighlighterInterceptor;
 
 /**
  * Created by kevinmayfield on 21/07/2017.
@@ -20,12 +23,66 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 @ComponentScan(basePackages = "uk.nhs.careconnect.ri")
 public class Config {
 
+    @Value("${datasource.cleardown.cron:0 19 21 * * *}")
+    private String cron;
+
+    @Value("${fhir.resource.serverBase}")
+    private String serverBase;
+
+    @Value("${fhir.resource.serverName}")
+    private String serverName;
+
+    @Value("${fhir.resource.serverVersion}")
+    private String serverVersion;
+
+    @Value("${fhir.oauth2.authorize:http://purple.testlab.nhs.uk:20080/authorize}")
+    private String oauth2authorize;
+
+    @Value("${fhir.oauth2.token:http://purple.testlab.nhs.uk:20080/token}")
+    private String oauth2token;
+
+    @Value("${fhir.oauth2.register:http://purple.testlab.nhs.uk:20080/register}")
+    private String oauth2register;
+
+    public String getServerBase() {
+        return this.serverBase;
+    }
+
+    public String getServerName() {
+        return this.serverName;
+    }
+
+    public String getServerVersion() {
+        return this.serverVersion;
+    }
+
+    public String getOauth2authorize() {
+        return this.oauth2authorize;
+    }
+
+    public String getOauth2token() {
+        return this.oauth2token;
+    }
+
+    public String getOauth2register() {
+        return this.oauth2register;
+    }
+
+    public String getCron() {
+        return this.cron;
+    }
+
     @Bean
     public FhirContext getFhirContext() {
         return FhirContext.forDstu3();
     }
 
-    @Value("${datasource.cleardown.cron:0 19 21 * * *}")
-    private String cron;
-
+    /**
+     * This interceptor adds some pretty syntax highlighting in responses when a browser is detected
+     */
+    @Bean(autowire = Autowire.BY_TYPE)
+    public IServerInterceptor responseHighlighterInterceptor() {
+        ResponseHighlighterInterceptor retVal = new ResponseHighlighterInterceptor();
+        return retVal;
+    }
 }

--- a/ccri-fhirgatewayhttps/src/main/java/uk/nhs/careconnect/ri/gateway/https/HAPIRestfulConfig.java
+++ b/ccri-fhirgatewayhttps/src/main/java/uk/nhs/careconnect/ri/gateway/https/HAPIRestfulConfig.java
@@ -5,12 +5,7 @@ import ca.uhn.fhir.context.FhirVersionEnum;
 import ca.uhn.fhir.rest.api.EncodingEnum;
 import ca.uhn.fhir.rest.server.HardcodedServerAddressStrategy;
 import ca.uhn.fhir.rest.server.RestfulServer;
-import ca.uhn.fhir.rest.server.interceptor.IServerInterceptor;
-import ca.uhn.fhir.rest.server.interceptor.ResponseHighlighterInterceptor;
 import ca.uhn.fhir.util.VersionUtil;
-import org.springframework.beans.factory.annotation.Autowire;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Bean;
 import org.springframework.web.context.ContextLoaderListener;
 import org.springframework.web.context.WebApplicationContext;
 import uk.nhs.careconnect.ri.gateway.https.oauth2.OAuth2Interceptor;
@@ -29,24 +24,6 @@ public class HAPIRestfulConfig extends RestfulServer {
 
 	private WebApplicationContext myAppCtx;
 
-	@Value("${fhir.resource.serverBase}")
-	private String serverBase;
-
-    @Value("${fhir.resource.serverName}")
-    private String serverName;
-
-    @Value("${fhir.resource.serverVersion}")
-    private String serverVersion;
-
-	@Value("${fhir.oauth2.authorize:https://auth.hspconsortium.org/authorize}")
-	private String oauth2authorize = "http://purple.testlab.nhs.uk:20080/authorize";
-
-	@Value("${fhir.oauth2.token:https://auth.hspconsortium.org/token}")
-	private String oauth2token = "http://purple.testlab.nhs.uk:20080/token";
-
-	@Value("${fhir.oauth2.register:https://auth.hspconsortium.org/register}")
-	private String oauth2register = "http://purple.testlab.nhs.uk:20080/register";
-
     @Override
 	public void addHeadersToResponse(HttpServletResponse theHttpResponse) {
 		theHttpResponse.addHeader("X-Powered-By", "HAPI FHIR " + VersionUtil.getVersion() + " RESTful Server (NHS Care Connect STU3)");
@@ -64,6 +41,21 @@ public class HAPIRestfulConfig extends RestfulServer {
 
 		// Get the spring context from the web container (it's declared in web.xml)
 		myAppCtx = ContextLoaderListener.getCurrentWebApplicationContext();
+		Config cfg = myAppCtx.getBean(Config.class);
+  
+		String serverBase = cfg.getServerBase();
+		String serverName = cfg.getServerName();
+		String serverVersion = cfg.getServerVersion();
+		String oauth2authorize = cfg.getOauth2authorize();
+		String oauth2token = cfg.getOauth2token();
+		String oauth2register = cfg.getOauth2register();
+
+		ourLog.info("serverBase: " + serverBase);
+		ourLog.info("oauth2authorize: " + oauth2authorize);
+		ourLog.info("oauth2token: " + oauth2token);
+		ourLog.info("oauth2register: " + oauth2register);
+		ourLog.info("serverName: " + serverName);
+		ourLog.info("serverVersion: " + serverVersion);
 
         if (serverBase != null && !serverBase.isEmpty()) {
             setServerAddressStrategy(new HardcodedServerAddressStrategy(serverBase));
@@ -118,16 +110,6 @@ public class HAPIRestfulConfig extends RestfulServer {
 		FhirContext ctx = getFhirContext();
 		// Remove as believe due to issues on docker ctx.setNarrativeGenerator(new DefaultThymeleafNarrativeGenerator());
 	}
-
-	/**
-	 * This interceptor adds some pretty syntax highlighting in responses when a browser is detected
-	 */
-	@Bean(autowire = Autowire.BY_TYPE)
-	public IServerInterceptor responseHighlighterInterceptor() {
-		ResponseHighlighterInterceptor retVal = new ResponseHighlighterInterceptor();
-		return retVal;
-	}
-
 
 
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,6 +87,9 @@ services:
       - fhir.restserver.serverBase=http4://${FHIR_SERVER_BASE_HOST}/careconnect-ri/STU3?throwExceptionOnFailure=false&bridgeEndpoint=true
       - fhir.restserver.edmsBase=http4://127.0.0.1:8184/STU3?throwExceptionOnFailure=false&bridgeEndpoint=true
       - fhir.restserver.oauth=http4:194.189.27.194:20080?throwExceptionOnFailure=false&bridgeEndpoint=true
+      - fhir.oauth2.authorize=https://purple.testlab.nhs.uk:20080/authorize
+      - fhir.oauth2.token=https://purple.testlab.nhs.uk:20080/token
+      - fhir.oauth2.register=https://purple.testlab.nhs.uk:20080/register
     depends_on:
       - ccri
     ports:


### PR DESCRIPTION
Configuration properties have been moved from HAPIRestfulConfig into the
existing Config classes. The Config classes are Spring @Configuration classes
enabling the @Value annotations to work, which they did not in the
HAPIRestfulConfig classes. This makes it possible to set the oauth2
endpoints in the docker-compose.yml file.