### PR TITLE
intermittent cyclic dependency problem prevents start-up

### DIFF
--- a/ccri-fhirgatewayhttps/pom.xml
+++ b/ccri-fhirgatewayhttps/pom.xml
@@ -384,6 +384,7 @@
 				<artifactId>maven-war-plugin</artifactId>
 				<version>2.6</version>
 				<configuration>
+                                        <packagingExcludes>WEB-INF/lib/bcprov-jdk14-*.jar</packagingExcludes>
 					<archive>
 						<manifestEntries>
 							<Build-Time>${maven.build.timestamp}</Build-Time>


### PR DESCRIPTION
Dependency resolution pulls multiple versions of lib/bcprov-*.jar
into the final WAR file - for example WEB-INF/lib/bcprov-jdk15on-1.56.jar
and WEB-INF/lib/bcprov-jdk14-1.38.jar.  Sometimes this prevents the
ccrigatewayhttps server from starting with "illegal cyclic inheritance dependencies".
This fix prevents the jdk14 version from being added to the WAR file.
See https://stackoverflow.com/questions/17584495 for more details.