### PR TITLE
honor wildcard Authorization scopes

### DIFF
--- a/ccri-fhirgatewayhttps/src/main/java/uk/nhs/careconnect/ri/gateway/https/oauth2/OAuthToken.java
+++ b/ccri-fhirgatewayhttps/src/main/java/uk/nhs/careconnect/ri/gateway/https/oauth2/OAuthToken.java
@@ -61,7 +61,8 @@ public class OAuthToken {
      * @return A Predicate to find the Scopes which match this Resource.
      */
     private Predicate<String> getScopeFilter(String requiredScoped, String method) {
-        String scopeRegex = String.format("^\\w*/%1s\\..*", requiredScoped);
+        // Match either the resource name or wildcard '*'
+        String scopeRegex = String.format("^\\w*/(?:\\*|%1s)\\..*", requiredScoped);
         return scope -> scope.matches(scopeRegex);
     }
 }


### PR DESCRIPTION
The scope match is extended to succeed against wildcard Resources
such as "patient/*.read" in addition to "patient/Patient.read".